### PR TITLE
[FIX: 1]: new format for `attr-quote-style`

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,10 @@ module.exports = {
     ],
     "attr-no-dup": true,
     "attr-no-unsafe-char": true,
-    "attr-quote-style": "double",
+    "attr-quote-style": [
+      true,
+      "double"
+    ],
     "attr-req-value": true,
     "attr-validate": true,
     "class-no-dup": true,

--- a/index.js
+++ b/index.js
@@ -84,6 +84,9 @@ module.exports = {
       "always"
     ],
     "title-no-dup": true,
-    "title-max-len": 60
+    "title-max-len": [
+      true,
+      60
+    ],
   }
 };


### PR DESCRIPTION
Fix Issue #1 
Invalid Config for rule "attr-quote-style" - Unexpected string value "double"

__This PR has been created because:__
the rule `attr-quote-style` was still written used the deprecated way inherited from htmllint
causing an error when trying to use `extends` on the new format config

__If merged the PR will:__
write the rules:
- `attr-quote-style`
- `title-max-len`
using the new format.

I spotted the second rule to be in the wrong format while fixing the first one




